### PR TITLE
Add rules for stylistic multiline

### DIFF
--- a/src/stylistic.js
+++ b/src/stylistic.js
@@ -266,6 +266,14 @@ export default [
 					"multilineDetection": "brackets",
 				},
 			],
+			"@stylistic/multiline-comment-style": [
+				"error", "starred-block",
+			],
+			"@stylistic/multiline-ternary": [
+				"error", "always", {
+					"ignoreJSX": false,
+				},
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Configure stylistic rules for multiline
- comment-style
- ternary