### PR TITLE
Change rule configuration for keyword-spacing

### DIFF
--- a/src/stylistic.js
+++ b/src/stylistic.js
@@ -205,7 +205,7 @@ export default [
 						"function": { "after": true, },
 						"get": { "after": true, },
 						"if": { "after": true, },
-						"import": { "after": false, },
+						"import": { "after": true, },
 						"in": { "after": true, },
 						"let": { "after": true, },
 						"new": { "after": true, },


### PR DESCRIPTION
Update keyword-spacing rule
- enforce `import` followed by one space