### PR TITLE
Update no-unused-vars rule for ignoreClassWithStaticInitBlock

### DIFF
--- a/src/eslint.js
+++ b/src/eslint.js
@@ -202,7 +202,7 @@ export default [
                     "caughtErrors": "all",
                     "caughtErrorsIgnorePattern": "",
                     "destructuredArrayIgnorePattern": "",
-                    "ignoreClassWithStaticInitBlock": "",
+                    "ignoreClassWithStaticInitBlock": false,
                     "ignoreRestSiblings": false,
                     "ignoreUsingDeclarations": false,
                     "reportUsedIgnorePattern": false,


### PR DESCRIPTION
Fix no-unused-vars
- ignoreClassWithStaticInitBlock from `""` to `false`