### PR TITLE
Add jsx-a11y rule aria-activedescendant-has-tabindex

### DIFF
--- a/src/jsx-a11y.js
+++ b/src/jsx-a11y.js
@@ -21,6 +21,9 @@ export default [
                     "aspects": ["noHref", "invalidHref", "preferButton"],
                 },
             ],
+            "jsx-a11y/aria-activedescendant-has-tabindex": [
+                "error",
+            ],
         },
     },
 ];


### PR DESCRIPTION
Add jsx-a11y rule for aria-activedescendant-has-tabindex