### PR TITLE
 Missing markdown namespace for no-duplicate-headings

### DIFF
--- a/src/markdown.js
+++ b/src/markdown.js
@@ -20,7 +20,7 @@ export default [
                     "allowFootnoteDefinitions": [],
                 },
             ],
-            "no-duplicate-headings": [
+            "markdown/no-duplicate-headings": [
                 "error", {
                     "checkSiblingsOnly": false,
                 },


### PR DESCRIPTION
Missing markdown namespace for no-duplicate-headings