### PR TITLE
Typo for stylistic jsx-sort-props

### DIFF
--- a/src/stylistic.js
+++ b/src/stylistic.js
@@ -246,7 +246,7 @@ export default [
 			"@stylistic/jsx-sort-props": [
 				"error", {
 					"ignoreCase": false,
-					"callbackLast": true,
+					"callbacksLast": true,
 					"shorthandFirst": false,
 					"shorthandLast": true,
 					"multiline": "last",


### PR DESCRIPTION
Fix typo for the stylistic rule jsx-sort-props "callbacksLast"