### PR TITLE
Forbid-component-props object

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -41,7 +41,7 @@ export default [
             ],
             "react/forbid-component-props": [
                 "error", {
-                    forbid: ['className', 'style'],
+                    "forbid": ['className', 'style'],
                 },
             ],
             "react/forbid-dom-props": [


### PR DESCRIPTION
Forbid-component-props object fixes by adding double quotes