### PR TITLE
Remove react rule jsx-sort-default-props

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -260,11 +260,6 @@ export default [
 					"exceptions": [],
 				},
 			],
-			"react/jsx-sort-default-props": [
-				"error", {
-					"ignoreCase": false,
-				},
-			],
 			"react/jsx-sort-props": [
 				"error", {
 					"ignoreCase": false,


### PR DESCRIPTION
Remove react rule for jsx-sort-default-props