### PR TITLE
Add typescript-eslint rule adjacent-overload-signatures

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -1,0 +1,9 @@
+export default [
+    {
+        rules: {
+            "typescript-eslint/adjacent-overload-signatures": [
+                "error",
+            ],
+        },
+    },
+];


### PR DESCRIPTION
Add typescript-eslint rule for adjacent-overload-signatures