### PR TITLE
Add typescript-eslint rule consistent-type-definitions

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -41,6 +41,9 @@ export default [
                     "arrayLiteralTypeAssertions": "allow",
                 },
             ],
+            "@typescript-eslint/consistent-type-definitions": [
+                "error", "interface",
+            ],
         },
     },
 ];


### PR DESCRIPTION
Add typescript-eslint rule for consistent-type-definitions