### PR TITLE
Add typescript-eslint rule explicit-module-boundary-types

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -90,6 +90,16 @@ export default [
                     },
                 },
             ],
+            "@typescript-eslint/explicit-module-boundary-types": [
+                "error", {
+                    "allowArgumentsExplicitlyTypedAsAny": false,
+                    "allowDirectConstAssertionInArrowFunctions": true,
+                    "allowedNames": [],
+                    "allowHigherOrderFunctions": true,
+                    "allowOverloadFunctions": false,
+                    "allowTypedFunctionExpressions": true,
+                },
+            ],
         },
     },
 ];


### PR DESCRIPTION
Add typescript-eslint rule for explicit-module-boundary-types