### PR TITLE
Add typescript-eslint rule no-dupe-class-members

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -142,6 +142,9 @@ export default [
 					"allow": [],
 				},
 			],
+			"@typescript-eslint/no-dupe-class-members": [
+				"error",
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-dupe-class-members