### PR TITLE
Add typescript-eslint rule no-empty-object-type

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -162,6 +162,12 @@ export default [
 					"allow": [],
 				},
 			],
+			"@typescript-eslint/no-empty-object-type": [
+				"error", { 
+					"allowInterfaces": 'never',
+					"allowObjectTypes": 'never',
+				},
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-empty-object-type