### PR TITLE
Add typescript-eslint rule no-extra-no-floating-promises

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -185,6 +185,15 @@ export default [
 					"allowWithDecorator": false,
 				},
 			],
+			"@typescript-eslint/no-floating-promises": [
+				"error", {
+					"allowForKnownSafeCalls": [],
+					"allowForKnownSafePromises": [],
+					"checkThenables": true,
+					"ignoreIIFE": false,
+					"ignoreVoid": false,
+				},
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-extra-no-floating-promises