### PR TITLE
Add typescript-eslint rule no-inferrable-types

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -203,6 +203,12 @@ export default [
 			"@typescript-eslint/no-import-type-side-effects": [
 				"error",
 			],
+			"@typescript-eslint/no-inferrable-types": [
+				"error", {
+					"ignoreParameters": false,
+					"ignoreProperties": false,
+				},
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-inferrable-types