### PR TITLE
Add typescript-eslint rule no-meaningless-void-operator

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -241,6 +241,11 @@ export default [
 					"ignoreTypeIndexes": false,
 				},
 			],
+			"@typescript-eslint/no-meaningless-void-operator": [
+				"error", {
+					"checkNever": false,
+				},
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-meaningless-void-operator