### PR TITLE
Add typescript-eslint rule no-non-null-asserted-optional-chain

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -280,6 +280,9 @@ export default [
 			"@typescript-eslint/no-non-null-asserted-nullish-coalescing": [
 				"error",
 			],
+			"@typescript-eslint/no-non-null-asserted-optional-chain": [
+				"error",
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-non-null-asserted-optional-chain