### PR TITLE
Add typescript-eslint rule no-redundant-type-constituents

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -292,6 +292,9 @@ export default [
 					"ignoreDeclarationMerge": false,
 				},
 			],
+			"@typescript-eslint/no-redundant-type-constituents": [
+				"error",
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-redundant-type-constituents