### PR TITLE
Add typescript-eslint rule no-unnecessary-boolean-literal-compare

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -325,6 +325,12 @@ export default [
 					"allowedNames": [],
 				},
 			],
+			"@typescript-eslint/no-unnecessary-boolean-literal-compare": [
+				"error", {
+					"allowComparingNullableBooleansToFalse": false,
+					"allowComparingNullableBooleansToTrue": false,
+				},
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-unnecessary-boolean-literal-compare