### PR TITLE
Add typescript-eslint rule no-unnecessary-type-arguments

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -346,6 +346,9 @@ export default [
 			"@typescript-eslint/no-unnecessary-template-expression": [
 				"error",
 			],
+			"@typescript-eslint/no-unnecessary-type-arguments": [
+				"error",
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-unnecessary-type-arguments