### PR TITLE
Add typescript-eslint rule no-unnecessary-type-conversion

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -358,6 +358,9 @@ export default [
 			"@typescript-eslint/no-unnecessary-type-constraint": [
 				"error",
 			],
+			"@typescript-eslint/no-unnecessary-type-conversion": [
+				"error",
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-unnecessary-type-conversion