### PR TITLE
Add typescript-eslint rule no-unnecessary-type-parameters

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -361,6 +361,9 @@ export default [
 			"@typescript-eslint/no-unnecessary-type-conversion": [
 				"error",
 			],
+			"@typescript-eslint/no-unnecessary-type-parameters": [
+				"error",
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-unnecessary-type-parameters