### PR TITLE
Add typescript-eslint rule no-unsafe-enum-comparison

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -376,6 +376,9 @@ export default [
 			"@typescript-eslint/no-unsafe-declaration-merging": [
 				"error",
 			],
+			"@typescript-eslint/no-unsafe-enum-comparison": [
+				"error",
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-unsafe-enum-comparison