### PR TITLE
Add typescript-eslint rule no-unsafe-type-assertion

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -390,6 +390,9 @@ export default [
 			"@typescript-eslint/no-unsafe-return": [
 				"error",
 			],
+			"@typescript-eslint/no-unsafe-type-assertion": [
+				"error",
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-unsafe-type-assertion