### PR TITLE
Add typescript-eslint rule no-useless-empty-export

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -434,6 +434,9 @@ export default [
 			"@typescript-eslint/no-useless-constructor": [
 				"error",
 			],
+			"@typescript-eslint/no-useless-empty-export": [
+				"error",
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-useless-empty-export