### PR TITLE
Add typescript-eslint rule no-wrapper-object-types

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -437,6 +437,9 @@ export default [
 			"@typescript-eslint/no-useless-empty-export": [
 				"error",
 			],
+			"@typescript-eslint/no-wrapper-object-types": [
+				"error",
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for no-wrapper-object-types