### PR TITLE
Add typescript-eslint rule prefer-literal-enum-member

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -487,6 +487,11 @@ export default [
 			"@typescript-eslint/prefer-includes": [
 				"error",
 			],
+			"@typescript-eslint/prefer-literal-enum-member": [
+				"error", {
+					"allowBitwiseExpressions": false,
+				},
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for prefer-literal-enum-member