### PR TITLE
Add typescript-eslint rule prefer-readonly-parameter-types

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -533,6 +533,14 @@ export default [
 					"onlyInlineLambdas": false,
 				},
 			],
+			"@typescript-eslint/prefer-readonly-parameter-types": [
+				"error", {
+					"allow": [],
+					"checkParameterProperties": true,
+					"ignoreInferredTypes": false,
+					"treatMethodsAsReadonly": false,
+				},
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for prefer-readonly-parameter-types