### PR TITLE
Add typescript-eslint rule prefer-string-starts-ends-with

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -550,6 +550,11 @@ export default [
 			"@typescript-eslint/prefer-return-this-type": [
 				"error",
 			],
+			"@typescript-eslint/prefer-string-starts-ends-with": [
+				"error", {
+					"allowSingleElementEquality": "never",
+				},
+			],
 		},
 	},
 ];


### PR DESCRIPTION
Add typescript-eslint rule for prefer-string-starts-ends-with