### PR TITLE
Add react-testing-library rule for no-global-regexp-flag-in-query

### DIFF
--- a/src/react-testitng-library.js
+++ b/src/react-testitng-library.js
@@ -36,6 +36,9 @@ export default [
             "testing-library/no-dom-import": [
                 "error", "react",
             ],
+            "testing-library/no-global-regexp-flag-in-query": [
+                "error",
+            ],
 		},
 	},
 ];


### PR DESCRIPTION
Add react-testing-library rule for no-global-regexp-flag-in-query