### PR TITLE
Add react-testing-library rule for render-result-naming-convention

### DIFF
--- a/src/react-testitng-library.js
+++ b/src/react-testitng-library.js
@@ -106,6 +106,9 @@ export default [
                     "allowedMethods": [],
                 },
             ],
+            "testing-library/render-result-naming-convention": [
+                "error",
+            ],
 		},
 	},
 ];


### PR DESCRIPTION
Add react-testing-library rule for render-result-naming-convention