### PR TITLE
Add eslint-jsdoc rule check-param-names

### DIFF
--- a/src/jsdoc.js
+++ b/src/jsdoc.js
@@ -38,6 +38,18 @@ export default [
                     "wrapIndent": "",
                 },
             ],
+            "jsdoc/check-param-names": [
+                "error", {
+                    "allowExtraTrailingParamDocs": false,
+                    "checkDestructured": true,
+                    "checkRestProperty": true,
+                    "checkTypesPattern": "/^(?:[oO]bject|[aA]rray|PlainObject|Generic(?:Object|Array))$/v",
+                    "disableExtraPropertyReporting": false,
+                    "disableMissingParamChecks": false,
+                    "enableFixer": true,
+                    "useDefaultObjectProperties": true,
+                },
+            ],
 		},
 	},
 ];


### PR DESCRIPTION
Add eslint-jsdoc rule for check-param-names