### PR TITLE
Add eslint-jsdoc rule check-property-names

### DIFF
--- a/src/jsdoc.js
+++ b/src/jsdoc.js
@@ -50,6 +50,11 @@ export default [
                     "useDefaultObjectProperties": true,
                 },
             ],
+            "jsdoc/check-property-names": [
+                "error", {
+                    "enableFixer": true,
+                },
+            ],
 		},
 	},
 ];


### PR DESCRIPTION
Add eslint-jsdoc rule for check-property-names