### PR TITLE
Add eslint-jsdoc rule check-template-names

### DIFF
--- a/src/jsdoc.js
+++ b/src/jsdoc.js
@@ -67,6 +67,9 @@ export default [
                     "typed": true,
                 },
             ],
+            "jsdoc/check-template-names": [
+                "error",
+            ],
 		},
 	},
 ];


### PR DESCRIPTION
Add eslint-jsdoc rule for check-template-names