### PR TITLE
Add eslint-jsdoc rule escape-inline-tags

### DIFF
--- a/src/jsdoc.js
+++ b/src/jsdoc.js
@@ -111,6 +111,13 @@ export default [
                     "tags": [],
                 },
             ],
+            "jsdoc/escape-inline-tags": [
+                "error", {
+                    "allowedInlineTags": [],
+                    "enableFixer": true,
+                    "fixType": "backslash"
+                },
+            ],
 		},
 	},
 ];


### PR DESCRIPTION
Add eslint-jsdoc rule for escape-inline-tags