### PR TITLE
Add eslint-jsdoc rule imports-as-dependencies

### DIFF
--- a/src/jsdoc.js
+++ b/src/jsdoc.js
@@ -123,6 +123,9 @@ export default [
                     "contexts":["any"],
                 },
             ],
+            "jsdoc/imports-as-dependencies": [
+                "error",
+            ],
 		},
 	},
 ];


### PR DESCRIPTION
Add eslint-jsdoc rule for imports-as-dependencies